### PR TITLE
Correction bug affichage bâtiments / terrains

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -820,6 +820,9 @@ function computeParcelle(mutationsSection, idParcelle) {
 				.uniqBy(function (m) {
 					return `${m.code_type_local}@${m.surface_reelle_bati}`
 				})
+				.filter(function(m){
+        				return m.id_mutation === idMutation
+      				})
 				.value()
 
 			var terrains = _.chain(mutationsParcelle)
@@ -829,6 +832,9 @@ function computeParcelle(mutationsSection, idParcelle) {
 				.uniqBy(function (m) {
 					return `${m.code_nature_culture}@${m.code_nature_culture_special}@${m.surface_terrain}`
 				})
+				.filter(function(m){
+        				return m.id_mutation === idMutation
+      				})
 				.value()
 
 			return {


### PR DESCRIPTION
### Correction d'un bug affectant l'affichage des terrains et bâtiments pour une mutation donnée.
Lorsqu'on clique sur le bouton dropdown pour une mutation, l'intégralité des bâtiments et des terrains de la parcelle sont affichées. 
<table>
<tr><td><img width="150px" src='https://user-images.githubusercontent.com/3234544/57314907-d9347100-70f2-11e9-854c-d1d5d525790b.PNG'></td>
<td><img width="150px" src='https://user-images.githubusercontent.com/3234544/57314909-d9cd0780-70f2-11e9-825c-06f0b2b883f7.PNG'></td></tr></table


C'est parce que la liste des terrains et bâtiments ne sont pas filtrés pour l'id de la mutation en question (i.e. `idMutation`) lors de la création du vecteur `mutations`.
L'ajout d'un filtre pour l'id de la mutation dans la fonction `computeParcelle` résout le problème.